### PR TITLE
Fix typo in version mismatch message

### DIFF
--- a/ui/panel.py
+++ b/ui/panel.py
@@ -107,7 +107,7 @@ def draw_version_warning(f) -> Callable:
                 panel.operator('preferences.umi_draw_addon_dependency', icon='CHECKMARK', text='Check Addon Dependency')
 
         elif addon_version.local_version != supported_version:
-            header, panel = draw_custom_panel(layout, 'VersionMissmatch', 'Addon Version Missmatch', icon=WARNING_ICON)
+            header, panel = draw_custom_panel(layout, 'VersionMissmatch', 'Addon Version Mismatch', icon=WARNING_ICON)
             header.alert = True
             if panel:
                 panel.alert = True


### PR DESCRIPTION
Great plugin,

Just changed a typo in the version mismatch string that appears on the UI.

Missmatch -> Mismatch.

I didn't change any of the spellings that weren't string literals, because I'm not sure where the bindings for those are.

Feel free to merge, reject, or implement this change yourself. Thanks!